### PR TITLE
bug fix: was trying to convert jagged arrays to numpy views

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1201,16 +1201,14 @@ def fill_hist(
             if name not in data:
                 raise ValueError(f"missing data for histogram axis '{name}'")
 
-    # create numpy views for all data arrays
-    data = {name: np.asarray(data[name]) for name in data}
+    # create awkward views for all data arrays
+    data = {name: ak.Array(data[name]) for name in data}
 
     # correct last bin values
     for ax in correct_last_bin_axes:
         right_egde_mask = data[ax.name] == ax.edges[-1]
         if np.any(right_egde_mask):
-            # work on a copy to not change input values in-place
-            data[ax.name] = data[ax.name].copy()
-            data[ax.name][right_egde_mask] -= ax.widths[-1] * 1e-5
+            data[ax.name] = data[ax.name] - ax.widths[-1] * 1e-5
 
     # fill
     arrays = ak.flatten(ak.cartesian(data))


### PR DESCRIPTION
The changes from commit [cfec386](https://github.com/columnflow/columnflow/commit/cfec38626e2a9c0bf454a4ed2336d28c740c932a) made my analysis crash: the histograms always bin in category_ids which are store in a jagged awkward array. Consequently, applying np.asarray to it fails. The changes below restore the original behaviour.