### PR TITLE
Cat per process plot

### DIFF
--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -84,6 +84,7 @@ def plot_variable_variants(
     yscale: str | None = None,
     hide_errors: bool | None = None,
     variable_settings: dict | None = None,
+    initial: str = "Initial",
     **kwargs,
 ) -> plt.Figure:
     """
@@ -111,7 +112,7 @@ def plot_variable_variants(
                 "label": selector_step_labels.get(label, label),
             },
             "ratio_kwargs": {
-                "norm": hists["Initial"].values(),
+                "norm": hists[initial].values(),
             },
         }
         if hide_errors:
@@ -125,7 +126,7 @@ def plot_variable_variants(
     )
     # plot-function specific changes
     default_style_config["rax_cfg"]["ylim"] = (0., 1.1)
-    default_style_config["rax_cfg"]["ylabel"] = "Step / Initial"
+    default_style_config["rax_cfg"]["ylabel"] = "Step / " + initial
 
     style_config = law.util.merge_dicts(default_style_config, style_config, deep=True)
     if shape_norm:

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -131,8 +131,6 @@ def apply_variable_settings(
                 rebin_factor = int(rebin_factor)
                 h = h[{var_inst.name: hist.rebin(rebin_factor)}]
                 hists[proc_inst] = h
-
-
         # overflow and underflow bins
         overflow = getattr(var_inst, "overflow", False) or var_inst.x("overflow", False)
         underflow = getattr(var_inst, "underflow", False) or var_inst.x("underflow", False)

--- a/columnflow/tasks/cmsGhent/plotting.py
+++ b/columnflow/tasks/cmsGhent/plotting.py
@@ -25,7 +25,7 @@ class PlotVariablesCatsPerProcessBase(PlotVariablesBaseSingleShift):
             DotDict({
                 "categories": cats,
                 "process": proc_name,
-                "variable": var_name
+                "variable": var_name,
             })
             for proc_name in sorted(self.processes)
             for var_name in sorted(self.variables)
@@ -137,4 +137,3 @@ class PlotVariables1DCatsPerProcess(
     plot_function = PlotBase.plot_function.copy(
         default="columnflow.plotting.plot_functions_1d.plot_variable_variants",
     )
-

--- a/columnflow/tasks/cmsGhent/plotting.py
+++ b/columnflow/tasks/cmsGhent/plotting.py
@@ -1,0 +1,134 @@
+import law
+import luigi
+from collections import OrderedDict
+
+from columnflow.tasks.plotting import PlotVariablesBaseSingleShift
+from columnflow.tasks.framework.plotting import PlotBase1D, PlotBase
+from columnflow.tasks.framework.decorators import view_output_plots
+from columnflow.util import DotDict
+
+
+class PlotVariablesCatsPerProcessBase(PlotVariablesBaseSingleShift):
+
+    exclude_index = False
+
+    plot_function = PlotVariables1D.plot_function.copy(
+        default="columnflow.plotting.plot_functions_1d.plot_variable_variants",
+    )
+
+    initial = luigi.Parameter(
+        default="incl",
+        description="Name of category that is considered as initial reference.",
+    )
+
+    @classmethod
+    def resolve_param_values(cls, params):
+        params = super().resolve_param_values(params)
+        if params["initial"] not in params["categories"]:
+            params["categories"] = tuple([params["initial"], *params["categories"]])
+        return params
+
+    def create_branch_map(self):
+        return [
+            DotDict({"process": proc_name, "variable": var_name})
+            for proc_name in sorted(self.processes)
+            for var_name in sorted(self.variables)
+        ]
+
+    def output(self):
+        b = self.branch_data
+        cat_tag = "_".join(self.categories)
+        return {"plots": [
+            self.local_target(name)
+            for name in self.get_plot_names(f"plot__proc_{b.process}__cat_{cat_tag}__var_{b.variable}")
+        ]}
+
+    @law.decorator.log
+    @view_output_plots
+    def run(self):
+        import hist
+
+        # get the shifts to extract and plot
+        plot_shifts = law.util.make_list(self.get_plot_shifts())
+
+        # prepare config objects
+        variable_tuple = self.variable_tuples[self.branch_data.variable]
+        variable_insts = [
+            self.config_inst.get_variable(var_name)
+            for var_name in variable_tuple
+        ]
+        category_insts = [self.config_inst.get_category(c) for c in self.categories]
+        process_inst = self.config_inst.get_process(self.branch_data.process)
+        sub_process_insts = [sub for sub, _, _ in process_inst.walk_processes(include_self=True)]
+
+        # histogram data for process
+        process_hist = 0
+
+        with self.publish_step(f"plotting {self.branch_data.variable} for {process_inst.name}"):
+            for dataset, inp in self.input().items():
+                dataset_inst = self.config_inst.get_dataset(dataset)
+                h_in = inp["collection"][0]["hists"].targets[self.branch_data.variable].load(formatter="pickle")
+
+                # extract one histogram for process
+                # skip when the dataset is already known to not contain any sub process
+                if not any(map(dataset_inst.has_process, sub_process_insts)):
+                    continue
+
+                # work on a copy
+                h = h_in.copy()
+
+                # axis selections
+                h = h[{
+                    "process": [
+                        hist.loc(p.id)
+                        for p in sub_process_insts
+                        if p.id in h.axes["process"]
+                    ],
+                    "category": [
+                        hist.loc(c.id)
+                        for c in category_insts
+                        if c.id in h.axes["category"]
+                    ],
+                    "shift": [
+                        hist.loc(s.id)
+                        for s in plot_shifts
+                        if s.id in h.axes["shift"]
+                    ],
+                }]
+
+                # axis reductions
+                h = h[{"process": sum}]
+
+                # add the histogram
+                process_hist = h + process_hist
+
+            # there should be hists to plot
+            if not process_hist:
+                raise Exception(
+                    "no histograms found to plot; possible reasons:\n" +
+                    "  - requested variable requires columns that were missing during histogramming\n" +
+                    "  - selected --processes did not match any value on the process axis of the input histogram",
+                )
+
+            process_hists = OrderedDict(
+                (cat.name, h[{"category": hist.loc(cat.id)}])
+                for cat in category_insts
+            )
+            # call the plot function
+            fig, _ = self.call_plot_func(
+                self.plot_function,
+                hists=process_hists,
+                config_inst=self.config_inst,
+                category_inst=process_inst.copy_shallow(),
+                variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
+                style_config={
+                    "legend_cfg": {"title": process_inst.label},
+                    "rax_cfg": {"ylabel": "Category / " + self.initial},
+                },
+                initial=self.initial,
+                **self.get_plot_parameters(),
+            )
+
+            # save the plot
+            for outp in self.output()["plots"]:
+                outp.dump(fig, formatter="mpl")


### PR DESCRIPTION
added task to plot multiple categories on one plot.  Uses the existing plot_variable_variants with slight modication to allow selecting a "initial" histogram (for ratios) with a different name