### PR TITLE
fixes multi category task

### DIFF
--- a/columnflow/tasks/cmsGhent/plotting.py
+++ b/columnflow/tasks/cmsGhent/plotting.py
@@ -23,6 +23,7 @@ class PlotVariablesCatsPerProcessBase(PlotVariablesBaseSingleShift):
             cats = [self.initial, *cats]
         return [
             DotDict({
+                "category": law.util.create_hash(cats),
                 "categories": cats,
                 "process": proc_name,
                 "variable": var_name,
@@ -32,11 +33,9 @@ class PlotVariablesCatsPerProcessBase(PlotVariablesBaseSingleShift):
         ]
 
     def output(self):
-        b = self.branch_data
-        cat_tag = "_".join(b.categories)
         return {"plots": [
             self.local_target(name)
-            for name in self.get_plot_names(f"plot__proc_{b.process}__cat_{cat_tag}__var_{b.variable}")
+            for name in self.get_plot_names("plot")
         ]}
 
     @law.decorator.log
@@ -150,6 +149,7 @@ class PlotVariables2DMigration(
     def create_branch_map(self):
         return [
             DotDict({
+                "category": self.initial + "_" + cat_name,
                 "categories": [self.initial, cat_name],
                 "process": proc_name,
                 "variable": var_name,
@@ -158,4 +158,3 @@ class PlotVariables2DMigration(
             for proc_name in sorted(self.processes)
             for var_name in sorted(self.variables)
         ]
-


### PR DESCRIPTION
parent task does not allow removing category argument in branch data. It's is used in naming the files. So put a combined category name there instead.
Also the self.get_plot_names function now automatically adds the process, category, and variable (based on the method plot_parts from defined in the task PlotVariablesBaseSingleShift [here](https://github.com/GhentAnalysis/columnflow/blob/76bbeb68eb4c16e9a5830d8fc85770415089017f/columnflow/tasks/plotting.py#L225C9-L225C19). So I removed this information from the string passed to it.