### PR TITLE
custom method function

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -236,12 +236,12 @@ def plot_all(
             raise ValueError(f"no histogram(s) given in plot_cfg entry {key}")
         hist = cfg["hist"]
         kwargs = cfg.get("kwargs", {})
-        plot_methods[method](ax, hist, **kwargs)
+        (plot_methods[method] if isinstance(method, str) else method)(ax, hist, **kwargs)
 
         if not skip_ratio and "ratio_kwargs" in cfg:
             # take ratio_method if the ratio plot requires a different plotting method
             method = cfg.get("ratio_method", method)
-            plot_methods[method](rax, hist, **cfg["ratio_kwargs"])
+            (plot_methods[method] if isinstance(method, str) else method)(rax, hist, **cfg["ratio_kwargs"])
 
     # axis styling
     ax_kwargs = {


### PR DESCRIPTION
allow to specify own custom function rather then the predefined ones. You can do then smth like:

```python    

from columnflow.plotting.plot_all import plot_all

def my_plot(*args, **kwargs):
    plot_config = {
        "my_plot": {
            "hist": [[0, 1], [0, 1]],
            "method": lambda ax, hist, **kwargs: ax.plot(*hist, **kwargs),
            "kwargs": dict(
                color="red",
                label="my random plot",
            )
        }
    }
    return plot_all(plot_config, style_config={})
```

which can be run like this:
```bash
law run cf.PlotVariables1D --plot-function singletop.plotting.my_plot --categories SOME_CAT --version test --variables SOME_VAR 
```
(note that the specific category or variables are irrelevant for `my_plot` since this example doesn't use any of it's arguments.)

This outputs:
![image](https://github.com/GhentAnalysis/columnflow/assets/52047931/4b15ceff-63d6-4e3f-8983-4f6d17d0becd)


