### PR TITLE
Enhance tetravec

### DIFF
--- a/columnflow/columnar_util_Ghent.py
+++ b/columnflow/columnar_util_Ghent.py
@@ -23,18 +23,18 @@ def TetraVec(arr: ak.Array, keep: Sequence | str | Literal[-1] = -1) -> ak.Array
     create a Lorentz for fector from an awkward array with pt, eta, phi, and mass fields
     """
     mandatory_fields = ("pt", "eta", "phi", "mass")
+    exclude_fields = ("x", "y", "z", "t")
     for field in mandatory_fields:
         assert hasattr(arr, field), f"Provided array is missing {field} field"
     if isinstance(keep, str):
-        keep = [keep, *mandatory_fields]
+        keep = [keep]
     elif keep == -1:
         keep = arr.fields
-    else:
-        keep = [*keep, *mandatory_fields]
+    keep = [*keep, *mandatory_fields]
     return ak.zip(
-        {p: getattr(arr, p) for p in keep},
+        {p: getattr(arr, p) for p in keep if p not in exclude_fields},
         with_name="PtEtaPhiMLorentzVector",
-        behavior=coffea.nanoevents.methods.vector.behavior
+        behavior=coffea.nanoevents.methods.vector.behavior,
     )
 
 

--- a/columnflow/columnar_util_Ghent.py
+++ b/columnflow/columnar_util_Ghent.py
@@ -16,16 +16,19 @@ ak = maybe_import("awkward")
 coffea = maybe_import("coffea")
 
 
-def TetraVec(arr: ak.Array) -> ak.Array:
+def TetraVec(arr: ak.Array, keep=tuple()) -> ak.Array:
     """
     create a Lorentz for fector from an awkward array with pt, eta, phi, and mass fields
     """
-    for field in ["pt", "eta", "phi", "mass"]:
+    mandatory_fields = ("pt", "eta", "phi", "mass")
+    for field in mandatory_fields:
         assert hasattr(arr, field), f"Provided array is missing {field} field"
-    TetraVec = ak.zip({"pt": arr.pt, "eta": arr.eta, "phi": arr.phi, "mass": arr.mass},
-    with_name="PtEtaPhiMLorentzVector",
-    behavior=coffea.nanoevents.methods.vector.behavior)
-    return TetraVec
+    keep += mandatory_fields
+    return ak.zip(
+        {p: getattr(arr, p) for p in keep},
+        with_name="PtEtaPhiMLorentzVector",
+        behavior=coffea.nanoevents.methods.vector.behavior
+    )
 
 
 def safe_concatenate(arrays, *args, **kwargs):


### PR DESCRIPTION
previously TetraVec threw away all other fields of an array, only keeping pt, eta, phi, and mass, and adding the new properties coming with  PtEtaPhiMLorentzVector. I changed this behaviour so it does also keep selected fields or all by default.