### PR TITLE
replace load_nano_columns by load_columns

### DIFF
--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -167,7 +167,6 @@ class CreateCutflowHistograms(
 
         # prepare columns to load
         load_columns = read_columns | set(mandatory_coffea_columns)
-        load_nano_columns = {("events" + route) for route in read_columns} | set(mandatory_coffea_columns)
         load_sel_columns = {Route("steps.*")}
 
         # prepare histograms
@@ -211,7 +210,7 @@ class CreateCutflowHistograms(
         for (events, sel, *diffs), pos in self.iter_chunked_io(
             input_paths,
             source_type=["coffea_root"] + (len(input_paths) - 1) * ["awkward_parquet"],
-            read_columns=[load_nano_columns, load_sel_columns] + (len(input_paths) - 2) * [load_columns],
+            read_columns=[load_columns, load_sel_columns] + (len(input_paths) - 2) * [load_columns],
         ):
 
             # add the calibrated diffs and potentially new columns
@@ -262,7 +261,6 @@ class CreateCutflowHistograms(
                 # fill the raw point
                 fill_data = get_point()
                 fill_hist(histograms[var_key], fill_data, fill_kwargs={"step": self.initial_step})
-
                 # fill all other steps
                 mask = True
                 for step in steps:


### PR DESCRIPTION
the set load_nano_columns used to fetch variables in the nanoAOD differed from load_columns (used for parquet files) by a prefix "events", but this prefix seemed to make the variable fetching to fail. Just using load_columns also for nanoAOD on the other hand worked.