### PR TITLE
fix default resolution for calibrators and producers

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1369,7 +1369,7 @@ class MLModelTrainingMixin(MLModelMixinBase):
         :raises Exception: If the number of calibrator sequences does not match
             the number of configs used by the ML model.
         """
-        calibrators: Union[tuple[str], tuple[tuple[str]]] = params.get("calibrators") or ((),)
+        calibrators: Union[tuple[str], tuple[tuple[str]]] = params.get("calibrators") or (None,)
 
         # broadcast to configs
         n_configs = len(ml_model_inst.config_insts)
@@ -1494,7 +1494,7 @@ class MLModelTrainingMixin(MLModelMixinBase):
         :raises Exception: If the number of producer sequences does not match
             the number of configs used by the ML model.
         """
-        producers = params.get("producers") or ((),)
+        producers = params.get("producers") or (None,)
 
         # broadcast to configs
         n_configs = len(ml_model_inst.config_insts)


### PR DESCRIPTION
I found that currently columnflow does not use the default calibrators and producers if none are passed through the command line. Instead, it just assumes no calibrators or producers are required. Looking at the method `resolve_calibrators` in the mixin `MLModelTrainingMixin`.  I found the problem in the following line

```python
calibrators: Union[tuple[str], tuple[tuple[str]]] = params.get("calibrators") or ((),)
```

If no calibrators are specified, ((),) is taken which is not converted to the default specified in the config. But if I change it to 
```python
calibrators: Union[tuple[str], tuple[tuple[str]]] = params.get("calibrators") or (None,)
```
the conversion does happen. The same story applies to the producers.