### PR TITLE
Updating GhentAnalysis fork master branch

### DIFF
--- a/analysis_templates/cms_minimal/setup.sh
+++ b/analysis_templates/cms_minimal/setup.sh
@@ -134,6 +134,9 @@ setup___cf_short_name_lc__() {
         # source law's bash completion scipt
         source "$( law completion )" ""
 
+        # add completion to the claw command
+        complete -o bashdefault -o default -F _law_complete claw
+
         # silently index
         law index -q
     fi

--- a/bin/claw
+++ b/bin/claw
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Executable that conveniently triggers "cf_sandbox SANDBOX law ..." commands.
+# The SANDBOX is determined with the following precedence:
+# 1. CLAW_SANDBOX (env)
+# 2. analysis.default_columnar_sandbox (law.cfg)
+# 3. venv_columnar_dev (default)
+
+action() {
+    # get the target sandbox
+    local sandbox
+    if [ ! -z "${CLAW_SANDBOX}" ]; then
+        sandbox="${CLAW_SANDBOX}"
+    fi
+    if [ -z "${sandbox}" ]; then
+        local sandbox_tmp="$( law config analysis.default_columnar_sandbox 2>/dev/null )"
+        if [ "$?" = "0" ]; then
+            # extract the name of the sandbox, remove file extension, potentially add '_dev' suffix
+            sandbox_tmp="$( basename "${sandbox_tmp}" )"
+            sandbox_tmp="${sandbox_tmp%.*}"
+            [[ "${sandbox_tmp}" = *_dev ]] || sandbox_tmp="${sandbox_tmp}_dev"
+            sandbox="${sandbox_tmp}"
+        fi
+    fi
+    if [ -z "${sandbox}" ]; then
+        sandbox="venv_columnar_dev"
+    fi
+    # echo "sandbox '${sandbox}'"
+
+    # run the command
+    cf_sandbox "${sandbox}" law "$@"
+}
+action "$@"

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -203,7 +203,7 @@ def normalization_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Arra
     events = set_ak_column(events, self.weight_name, norm_weight, value_type=np.float32)
 
     # If we are stitching, we also compute the inclusive weight for debugging purposes
-    if self.allow_stitching and self.dataset_inst == self.inclusive_dataset:
+    if self.allow_stitching and self.get_xsecs_from_inclusive_dataset and self.dataset_inst == self.inclusive_dataset:
         incl_norm_weight = events.mc_weight * self.inclusive_weight
         events = set_ak_column(events, self.weight_name_incl, incl_norm_weight, value_type=np.float32)
     return events
@@ -349,7 +349,7 @@ def normalization_weights_init(self: Producer) -> None:
     else:
         self.stitching_datasets = [self.dataset_inst]
 
-    if self.allow_stitching and self.dataset_inst == self.inclusive_dataset:
+    if self.allow_stitching and self.get_xsecs_from_inclusive_dataset and self.dataset_inst == self.inclusive_dataset:
         self.weight_name_incl = f"{self.weight_name}_inclusive_only"
         self.produces.add(self.weight_name_incl)
 

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -339,6 +339,9 @@ def normalization_weights_init(self: Producer) -> None:
     """
     Initializes the normalization weights producer by setting up the normalization weight column.
     """
+    if getattr(self, "dataset_inst", None) is None:
+        return
+
     self.produces.add(self.weight_name)
     if self.allow_stitching:
         self.stitching_datasets = self.get_stitching_datasets()

--- a/columnflow/selection/stats.py
+++ b/columnflow/selection/stats.py
@@ -148,15 +148,15 @@ def increment_stats(
                     f"but found a sequence: {obj}",
                 )
             if len(obj) == 1:
-                weights = ak.values_astype(obj[0], float)
+                weights = ak.values_astype(obj[0], np.float64)
             elif len(obj) == 2:
-                weights, weight_mask = ak.values_astype(obj[0], float), obj[1]
+                weights, weight_mask = ak.values_astype(obj[0], np.float64), obj[1]
             else:
                 raise Exception(f"cannot interpret as weights and optional mask: '{obj}'")
         elif op == self.NUM:
             weight_mask = obj
         else:  # SUM
-            weights = ak.values_astype(obj, float)
+            weights = ak.values_astype(obj, np.float64)
 
         # when mask is an Ellipsis, it cannot be AND joined to other masks, so convert to true mask
         if weight_mask is Ellipsis:

--- a/columnflow/selection/stats.py
+++ b/columnflow/selection/stats.py
@@ -148,15 +148,15 @@ def increment_stats(
                     f"but found a sequence: {obj}",
                 )
             if len(obj) == 1:
-                weights = obj[0]
+                weights = ak.values_astype(obj[0], float)
             elif len(obj) == 2:
-                weights, weight_mask = obj
+                weights, weight_mask = ak.values_astype(obj[0], float), obj[1]
             else:
                 raise Exception(f"cannot interpret as weights and optional mask: '{obj}'")
         elif op == self.NUM:
             weight_mask = obj
         else:  # SUM
-            weights = obj
+            weights = ak.values_astype(obj, float)
 
         # when mask is an Ellipsis, it cannot be AND joined to other masks, so convert to true mask
         if weight_mask is Ellipsis:

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -265,7 +265,7 @@ class CreateDatacards(
             outputs = self.output()
             writer = DatacardWriter(self.inference_model_inst, {cat_obj.name: hists})
             with outputs["card"].localize("w") as tmp_card, outputs["shapes"].localize("w") as tmp_shapes:
-                writer.write(tmp_card.path, tmp_shapes.path, shapes_path_ref=outputs["shapes"].basename)
+                writer.write(tmp_card.abspath, tmp_shapes.abspath, shapes_path_ref=outputs["shapes"].basename)
 
 
 CreateDatacardsWrapper = wrapper_factory(

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -160,7 +160,7 @@ class CreateCutflowHistograms(
                     histograms[var_key] = h.Weight()
 
         for arr, pos in self.iter_chunked_io(
-            inputs["selection"]["masks"].path,
+            inputs["selection"]["masks"].abspath,
             source_type="awkward_parquet",
             read_columns=load_columns,
         ):

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -170,6 +170,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
         :param fs: Name of the local or remote file system where the LFNs are located, defaults to None
         :param lfn_indices: List of indices of LFNs that are processed by this *task* instance, defaults to None
         :param eager_lookup: Look at the next fs if stat takes too long, defaults to 1
+        :param skip_fallback: Skip the fallback mechanism to fetch the LFN, defaults to False
         :raises TypeError: If *task* is not of type :external+law:py:class:`~law.workflow.base.BaseWorkflow` or not
             a task analyzing a single branch in the task tree
         :raises Exception: If current task is not complete as indicated with ``self.complete()``
@@ -292,7 +293,8 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
         of the ``gfal2`` package).
 
         :param lfn: Logical file name to fetch.
-        :param selected_fs: Name of the file system to fetch the LFN from.
+        :param selected_fs: Name of the file system to fetch the LFN from. When remote, its *base*
+            or *base_filecopy* should use the `root://` protocol.
         :param force: When *True*, forces the fallback to be performed, defaults to *False*.
         :return: Tuple of the fetched file, its stat, and a flag indicating whether the file is
             temporary. *None*'s are returned when the file was not fetched.

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -426,7 +426,7 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
 
         # helper function to fetch generic files
         def fetch_file(src, counter=[0]):
-            dst = os.path.join(tmp_dir.path, self.create_unique_basename(src))
+            dst = os.path.join(tmp_dir.abspath, self.create_unique_basename(src))
             src = src[0] if isinstance(src, tuple) else src
             if src.startswith(("http://", "https://")):
                 # download via wget

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -142,10 +142,12 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
         if code != 0:
             raise Exception(f"dasgoclient query failed:\n{out}")
 
+        broken_files = dataset_inst[shift_inst.name].get_aux("broken_files", [])
+
         return [
             line.strip()
             for line in out.strip().split("\n")
-            if line.strip().endswith(".root")
+            if line.strip().endswith(".root") and line.strip() not in broken_files
         ]
 
     def iter_nano_files(

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -288,7 +288,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
         """
         Fetches an *lfn* via fallback mechanisms. Currently, only ``xrdcp`` for remote file systems
         *selected_fs* with `root://` bases is supported. Unless *force* is *True*, no fallbacks are
-        performed in case they are not necessary in the first place (determine by the availability
+        performed in case they are not necessary in the first place (determined by the availability
         of the ``gfal2`` package).
 
         :param lfn: Logical file name to fetch.
@@ -339,8 +339,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
                 wlcg_fs.cache.allocate(stat.st_size)
                 clfn = law.LocalFileTarget(wlcg_fs.cache.cache_path(lfn))
                 destination.move_to_local(clfn)
-            destination = clfn
-            return destination, stat, False
+            return clfn, stat, False
 
         # here, the destination will be temporary, but set its tmp flag to False to prevent its
         # deletion when this method goes out of scope, and set the decision for later use instead

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -887,7 +887,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
                 else law.MirroredDirectoryTarget
             )
             return mirrored_target_cls(
-                path=local_target.path,
+                path=local_target.abspath,
                 remote_target=wlcg_target,
                 local_target=local_target,
             )
@@ -1390,7 +1390,7 @@ class CommandTask(AnalysisTask):
         if "cwd" not in kwargs and self.run_command_in_tmp:
             tmp_dir = law.LocalDirectoryTarget(is_tmp=True)
             tmp_dir.touch()
-            kwargs["cwd"] = tmp_dir.path
+            kwargs["cwd"] = tmp_dir.abspath
         self.publish_message("cwd: {}".format(kwargs.get("cwd", os.getcwd())))
 
         # call it

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -871,15 +871,16 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             # get other options
             loc, wlcg_fs, store_parts_modifier = (location[1:] + [None, None, None])[:3]
             kwargs.setdefault("store_parts_modifier", store_parts_modifier)
+            # create the wlcg target
+            wlcg_kwargs = kwargs.copy()
+            wlcg_kwargs.setdefault("fs", wlcg_fs)
+            wlcg_target = self.wlcg_target(*path, **wlcg_kwargs)
+            # TODO: add rule for falling back to wlcg target
             # create the local target
             local_kwargs = kwargs.copy()
             loc_key = "fs" if (loc and law.config.has_section(loc)) else "store"
             local_kwargs.setdefault(loc_key, loc)
             local_target = self.local_target(*path, **local_kwargs)
-            # create the wlcg target
-            wlcg_kwargs = kwargs.copy()
-            wlcg_kwargs.setdefault("fs", wlcg_fs)
-            wlcg_target = self.wlcg_target(*path, **wlcg_kwargs)
             # build the mirrored target from these two
             mirrored_target_cls = (
                 law.MirroredFileTarget

--- a/columnflow/tasks/framework/decorators.py
+++ b/columnflow/tasks/framework/decorators.py
@@ -72,10 +72,10 @@ def view_output_plots(
                 continue
             if output.path.endswith((".pdf", ".png")):
                 if not isinstance(output, law.LocalTarget):
-                    task.logger.warning(f"cannot show non-local plot at '{output.path}'")
+                    task.logger.warning(f"cannot show non-local plot at '{output.abspath}'")
                     continue
                 elif output.path not in view_paths:
-                    view_paths.append(output.path)
+                    view_paths.append(output.abspath)
 
         # loop through paths and view them
         for path in view_paths:

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -26,7 +26,22 @@ class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLo
     user = user_parameter_inst
     version = None
 
-    exclude_files = ["docs", "tests", "data", "assets", ".law", ".setups", ".data", ".github"]
+    exclude_files = [
+        "docs",
+        "tests",
+        "data",
+        "assets",
+        ".law",
+        ".setups",
+        ".data",
+        ".github",
+        # also make sure that CF specific files that are not part of
+        # the repository are excluded
+        os.environ["CF_STORE_LOCAL"],
+        os.environ["CF_SOFTWARE_BASE"],
+        os.environ["CF_VENV_BASE"],
+        os.environ["CF_CONDA_BASE"],
+    ]
 
     def get_repo_path(self):
         # required by BundleGitRepository

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -172,7 +172,7 @@ class CreateHistograms(
             mode="r",
         ) as inps:
             for (events, *columns), pos in self.iter_chunked_io(
-                [inp.path for inp in inps],
+                [inp.abspath for inp in inps],
                 source_type=len(file_targets) * ["awkward_parquet"] + [None] * len(reader_targets),
                 read_columns=(len(file_targets) + len(reader_targets)) * [read_columns],
                 chunk_size=self.weight_producer_inst.get_min_chunk_size(),

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -204,7 +204,7 @@ class PrepareMLEvents(
             mode="r",
         ) as inps:
             for (events, *columns), pos in self.iter_chunked_io(
-                [inp.path for inp in inps],
+                [inp.abspath for inp in inps],
                 source_type=len(files) * ["awkward_parquet"] + [None] * len(reader_targets),
                 read_columns=(len(files) + len(reader_targets)) * [read_columns],
             ):
@@ -253,7 +253,7 @@ class PrepareMLEvents(
                     # save as parquet via a thread in the same pool
                     chunk = tmp_dir.child(f"file_{f}_{pos.index}.parquet", type="f")
                     output_chunks[f][pos.index] = chunk
-                    self.chunked_io.queue(sorted_ak_to_parquet, (fold_events, chunk.path))
+                    self.chunked_io.queue(sorted_ak_to_parquet, (fold_events, chunk.abspath))
 
             # merge output files of all folds
             for _output_chunks, output in zip(output_chunks, outputs["mlevents"].targets):
@@ -778,7 +778,7 @@ class MLEvaluation(
             mode="r",
         ) as inps:
             for (events, *columns), pos in self.iter_chunked_io(
-                [inp.path for inp in inps],
+                [inp.abspath for inp in inps],
                 source_type=len(file_targets) * ["awkward_parquet"] + [None] * len(reader_targets),
                 read_columns=(len(file_targets) + len(reader_targets)) * [read_columns],
             ):
@@ -828,7 +828,7 @@ class MLEvaluation(
                 # save as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
                 output_chunks[pos.index] = chunk
-                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
@@ -1033,7 +1033,7 @@ class PlotMLResultsBase(
                     "which is not implemented yet.",
                 )
 
-            events = ak.from_parquet(inp["mlcolumns"].path)
+            events = ak.from_parquet(inp["mlcolumns"].abspath)
 
             # masking with leaf categories
             category_mask = False

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -110,7 +110,7 @@ class ProduceColumns(
         ) as inps:
             # iterate over chunks of events and diffs
             for (events, *cols), pos in self.iter_chunked_io(
-                [inp.path for inp in inps],
+                [inp.abspath for inp in inps],
                 source_type=["awkward_parquet"] + [None] * n_ext,
                 read_columns=[read_columns] * (1 + n_ext),
                 chunk_size=self.producer_inst.get_min_chunk_size(),

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -144,7 +144,7 @@ class ProduceColumns(
                 # save as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
                 output_chunks[pos.index] = chunk
-                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -399,6 +399,8 @@ class MergeReducedEvents(
         f"removed after successful merging; default: {default_keep_reduced_events}",
     )
 
+    max_merge_factor = 50
+
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
 
     # upstream requirements
@@ -415,7 +417,7 @@ class MergeReducedEvents(
         Required by law.tasks.ForestMerge.
         """
         # return as many inputs as leafs are present to create the output of this tree, capped at 50
-        return min(self.file_merging, 50)
+        return min(self.file_merging, self.max_merge_factor)
 
     def is_sandboxed(self):
         # when the task is a merge forest, consider it sandboxed
@@ -443,7 +445,7 @@ class MergeReducedEvents(
     def merge_workflow_requires(self):
         return {
             "stats": self.reqs.MergeReductionStats.req(self),
-            "events": self.reqs.ReduceEvents.req(self, _exclude={"branches"}),
+            "events": self.reqs.ReduceEvents.req_different_branching(self, branches=((0, -1),)),
         }
 
     def merge_requires(self, start_branch, end_branch):

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -122,11 +122,11 @@ class UniteColumns(
         read_columns = {Route(c) for c in read_columns}
 
         # iterate over chunks of events and diffs
-        files = [inputs["events"]["events"].path]
+        files = [inputs["events"]["events"].abspath]
         if self.producer_insts:
-            files.extend([inp["columns"].path for inp in inputs["producers"]])
+            files.extend([inp["columns"].abspath for inp in inputs["producers"]])
         if self.ml_model_insts:
-            files.extend([inp["mlcolumns"].path for inp in inputs["ml"]])
+            files.extend([inp["mlcolumns"].abspath for inp in inputs["ml"]])
         for (events, *columns), pos in self.iter_chunked_io(
             files,
             source_type=len(files) * ["awkward_parquet"],
@@ -150,9 +150,9 @@ class UniteColumns(
             chunk = tmp_dir.child(f"file_{pos.index}.{self.file_type}", type="f")
             output_chunks[pos.index] = chunk
             if self.file_type == "parquet":
-                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
             else:  # root
-                self.chunked_io.queue(sorted_ak_to_root, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_root, (events, chunk.abspath))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]

--- a/docs/user_guide/ml.md
+++ b/docs/user_guide/ml.md
@@ -354,8 +354,8 @@ class MyModel(MLModel):
         # store parameters of interest in the ml_model_inst, e.g. via the parameters attribute
         self.parameters = {
             "batchsize": int(self.parameters.get("batchsize", 1024)),
-            "layers": tuple(int(layer) for layer in self.parameters.get("layers, (64, 64, 64)),
-            "ml_process_weights": ml_process_weights
+            "layers": tuple(int(layer) for layer in self.parameters.get("layers", (64, 64, 64))),
+            "ml_process_weights": ml_process_weights,
         }
 
         # create representation of ml_model_inst

--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -333,7 +333,7 @@ setup_cmssw() {
 
     # prepend persistent path fragments again to ensure priority for local packages and
     # remove the conda based python fragments since there are too many overlaps between packages
-    export PYTHONPATH="${CF_PERSISTENT_PATH}:$( echo ${PYTHONPATH} | sed "s|${CF_CONDA_PYTHONPATH}||g" )"
+    export PYTHONPATH="${CF_PERSISTENT_PYTHONPATH}:$( echo ${PYTHONPATH} | sed "s|${CF_CONDA_PYTHONPATH}||g" )"
     export PATH="${CF_PERSISTENT_PATH}:${PATH}"
 
     # mark this as a bash sandbox for law

--- a/setup.sh
+++ b/setup.sh
@@ -318,7 +318,7 @@ cf_setup_common_variables() {
     # used by law.cfg and, in turn, tasks/framework/remote.py
     local cf_htcondor_flavor_default="naf"
     local cf_slurm_flavor_default="maxwell"
-    local cf_slurm_partition_default="cms-uhh"
+    local cf_slurm_partition_default="maxgpu"
     local hname="$( hostname 2> /dev/null )"
     if [ "$?" = "0" ]; then
         # lxplus

--- a/setup.sh
+++ b/setup.sh
@@ -133,7 +133,10 @@ setup_columnflow() {
     #   PYTHONPATH
     #       Ammended PYTHONPATH variable.
     #   PYTHONWARNINGS
-    #       Set to "ignore".
+    #       Set to "ignore" when not defined already.
+    #   PYTHONNOUSERSITE
+    #       Set to "1" when not defined alreedy, to prevent python from loading packages from e.g.
+    #       "$HOME/.local", which can lead to encapsulation and debugging issues.
     #   GLOBUS_THREAD_MODEL
     #       Set to "none".
     #   VIRTUAL_ENV_DISABLE_PROMPT
@@ -591,6 +594,7 @@ cf_setup_software_stack() {
     export MAMBA_ROOT_PREFIX="${CF_CONDA_BASE}"
     export MAMBA_EXE="${MAMBA_ROOT_PREFIX}/bin/micromamba"
     export PYTHONWARNINGS="${PYTHONWARNINGS:-ignore}"
+    export PYTHONNOUSERSITE="${PYTHONNOUSERSITE:-1}"
     export GLOBUS_THREAD_MODEL="${GLOBUS_THREAD_MODEL:-none}"
     export VIRTUAL_ENV_DISABLE_PROMPT="${VIRTUAL_ENV_DISABLE_PROMPT:-1}"
     export X509_CERT_DIR="${X509_CERT_DIR:-/cvmfs/grid.cern.ch/etc/grid-security/certificates}"

--- a/setup.sh
+++ b/setup.sh
@@ -241,6 +241,9 @@ setup_columnflow() {
         # source law's bash completion scipt
         source "$( law completion )" ""
 
+        # add completion to the claw command
+        complete -o bashdefault -o default -F _law_complete claw
+
         # silently index
         law index -q
     fi


### PR DESCRIPTION
This pull request takes updates from the central columnflow to the GhentAnalysisFork. The main updates are listed below:

Major updates:
- stitching datasets is now possible within `columnflow/production/normalization.py`
- Fetch an *lfn* via a fallback mechanisms
- broken files can now be identified in the `cf.GetDataLFNs` task if the list of broken files is given in `dataset_inst.aux.broken_files`

Minor fixes:
- `.path` function is changed to `.abspath`

Cheers, Jules