### PR TITLE
removing faulty lines in variable matching

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -457,8 +457,6 @@ class AnalysisTask(BaseTask, law.SandboxTask):
                             matches[i].append(_name)
                 for matches_pair in itertools.product(*matches):
                     object_names.append("-".join(matches_pair))
-                    if law.util.multi_match(_name, name):
-                        object_names.append(_name)
 
         return law.util.make_unique(object_names)
 


### PR DESCRIPTION
for some reason, another match was performed here

```python
for matches_pair in itertools.product(*matches):
    object_names.append("-".join(matches_pair))
    if law.util.multi_match(_name, name):
        object_names.append(_name)
```
clearly a mistake (_name is a loop variable from a previous loop just above it)