### PR TITLE
Fix of sandbox cmssw_columnar for el9

### DIFF
--- a/sandboxes/cmssw_columnar.sh
+++ b/sandboxes/cmssw_columnar.sh
@@ -23,7 +23,7 @@ action() {
         # install a venv into ${CMSSW_BASE}/venvs, which is included by BundleCMSSWSandbox
         CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_create_venv columnar &&
         source "${CMSSW_BASE}/venvs/columnar/bin/activate" "" &&
-        pip install -r "${CF_BASE}/sandboxes/columnar.txt" &&
+        pip install -I -r "${CF_BASE}/sandboxes/columnar.txt" &&
         CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_make_venv_relocatable columnar
     }
     cf_cmssw_custom_setup() {

--- a/sandboxes/cmssw_columnar.sh
+++ b/sandboxes/cmssw_columnar.sh
@@ -13,8 +13,8 @@ action() {
 
     # set variables and source the generic CMSSW setup
     export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
-    export CF_SCRAM_ARCH="$( [ "${os_version}" = "8" ] && echo "el8" || echo "slc7" )_amd64_gcc10"
-    export CF_CMSSW_VERSION="CMSSW_12_6_2"
+    export CF_SCRAM_ARCH="el9_amd64_gcc11"
+    export CF_CMSSW_VERSION="CMSSW_13_0_19"
     export CF_CMSSW_ENV_NAME="$( basename "${this_file%.sh}" )"
     export CF_CMSSW_FLAG="1"  # increment when content changed
 


### PR DESCRIPTION
These changes update the `cmssw_columnar` sandbox:

- `CMSSW` updated from `12_6_2` to `13_0_19`
- `SCRAM_ARCH` updated from  `slc7` or `el8` to `el9`

This fix is useful for users that require `CMSSW` in columnflow tasks.