### PR TITLE
mixin to avoid rerunning get_param_values needlessly

### DIFF
--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -8,7 +8,7 @@ import luigi
 import law
 
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, DatasetTask, wrapper_factory
-from columnflow.tasks.framework.mixins import CalibratorMixin, ChunkedIOMixin
+from columnflow.tasks.framework.mixins import CalibratorMixin, ChunkedIOMixin, ParamsCacheMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox
@@ -17,6 +17,7 @@ ak = maybe_import("awkward")
 
 
 class CalibrateEvents(
+    ParamsCacheMixin,
     CalibratorMixin,
     ChunkedIOMixin,
     DatasetTask,
@@ -33,6 +34,7 @@ class CalibrateEvents(
 
     # default sandbox, might be overwritten by calibrator function
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
+    cache_param_sep = ["calibrator"]
 
     # upstream requirements
     reqs = Requirements(

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -2591,12 +2591,25 @@ class MergeHistogramMixin(
 
 class ParamsCacheMixin:
 
+    # the get_param_values is called again for every value of this parameter (config by default included)
     cache_param_sep = []
+
+    # dict to store cached params for different tasks
     cache_param_values = dict()
 
     time_get_params = luigi.BoolParameter(
         default=False,
         description="Whether to report the time taken to load get the parameters",
+    )
+
+    no_cached_params = luigi.BoolParameter(
+        default=False,
+        description="Return normal call to get_param_values and report if it differs from cached output",
+    )
+
+    check_cached_params = luigi.BoolParameter(
+        default=False,
+        description="Return normal call to get_param_values and report if it differs from cached output",
     )
 
     @classmethod
@@ -2609,21 +2622,48 @@ class ParamsCacheMixin:
 
     @classmethod
     def get_param_values(cls, params, args, kwargs):
+
         tag = cls.cache_tag(kwargs)
         cache = cls.cache_param_values.setdefault(tag, [])
         if cache:
+            # return cached params but overwrite branch(es), dataset, and output/status options
             dct_update = dict(branch=int(kwargs.get("branch", -1)))
             if "dataset" in kwargs:
                 dct_update["dataset"] = kwargs["dataset"]
-            out = cache[0] | dct_update | {
+            cached_out = cache[0] | dct_update | {
                 k: kwargs.get(k, ()) for k in
                 ["print_output", "branches", "print_status", "remove_output", "fetch_output"]
             }
-            return list(out.items())
-        if kwargs.get("print_timing", False):
-            tmr = Timer(f"{tag} get_param_values")
-        cache.append(dict(out := super().get_param_values(params, args, kwargs)))
-        cls.cache_param_values[cls.cache_tag(dict(out))] = cache
-        if kwargs.get("print_timing", False):
-            tmr("end")
-        return out
+
+        # call the normal get_param_values first time, or by request
+        if any([
+            check_cached_params := kwargs.get("check_cached_params", False),
+            no_cached_params := kwargs.get("no_cached_params", False),
+            first_call := not cache,
+        ]):
+            if time_get_params := kwargs.get("time_get_params", False):
+                tmr = Timer(f"{tag} get_param_values")
+
+            out = super().get_param_values(params, args, kwargs)
+
+            if time_get_params:
+                tmr("end of call")
+
+            dct_out = dict(out)
+
+        # store first call to cache
+        if first_call:
+            cache.append(dct_out)
+            cls.cache_param_values[cls.cache_tag(dct_out)] = cache
+        # compare cached output to normal call
+        elif check_cached_params:
+            for key, value in dct_out.items():
+                cached_val = cached_out.get(key, None)
+                if cached_val != value:
+                    logger.warning(
+                        "normal call to get_param_values yielded output that differs from cached output\n"
+                        f"Normal call -> {key} [key]: {value}\n"
+                        f"Cached call -> {key} [key]: {cached_val}",
+                    )
+
+        return out if no_cached_params or first_call else list(cached_out.items())

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -12,7 +12,7 @@ import law
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, VariablesMixin,
-    ShiftSourcesMixin, WeightProducerMixin, ChunkedIOMixin,
+    ShiftSourcesMixin, WeightProducerMixin, ChunkedIOMixin, ParamsCacheMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.framework.parameters import last_edge_inclusive_inst
@@ -24,6 +24,7 @@ from columnflow.hist_util import create_hist_from_variables
 
 
 class CreateHistograms(
+    ParamsCacheMixin,
     VariablesMixin,
     WeightProducerMixin,
     MLModelsMixin,
@@ -287,6 +288,7 @@ CreateHistogramsWrapper = wrapper_factory(
 
 
 class MergeHistograms(
+    ParamsCacheMixin,
     VariablesMixin,
     WeightProducerMixin,
     MLModelsMixin,

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -14,7 +14,7 @@ import order as od
 from columnflow.tasks.framework.base import Requirements, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, WeightProducerMixin,
-    CategoriesMixin, ShiftSourcesMixin, HistHookMixin,
+    CategoriesMixin, ShiftSourcesMixin, HistHookMixin, ParamsCacheMixin,
 )
 from columnflow.tasks.framework.plotting import (
     PlotBase, PlotBase1D, PlotBase2D, ProcessPlotSettingMixin, VariablePlotSettingMixin,
@@ -26,6 +26,7 @@ from columnflow.util import DotDict, dev_sandbox, dict_add_strict
 
 
 class PlotVariablesBase(
+    ParamsCacheMixin,
     HistHookMixin,
     VariablePlotSettingMixin,
     ProcessPlotSettingMixin,

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -15,7 +15,7 @@ import luigi
 
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.mixins import (
-    CalibratorsMixin, SelectorStepsMixin, ChunkedIOMixin,
+    CalibratorsMixin, SelectorStepsMixin, ChunkedIOMixin, ParamsCacheMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
@@ -30,6 +30,7 @@ default_keep_reduced_events = law.config.get_expanded("analysis", "default_keep_
 
 
 class ReduceEvents(
+    ParamsCacheMixin,
     SelectorStepsMixin,
     CalibratorsMixin,
     ChunkedIOMixin,

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -11,7 +11,7 @@ import luigi
 import law
 
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, DatasetTask, wrapper_factory
-from columnflow.tasks.framework.mixins import CalibratorsMixin, SelectorMixin, ChunkedIOMixin
+from columnflow.tasks.framework.mixins import CalibratorsMixin, SelectorMixin, ChunkedIOMixin, ParamsCacheMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.tasks.calibration import CalibrateEvents
@@ -32,6 +32,7 @@ default_create_selection_hists = law.config.get_expanded_bool(
 
 
 class SelectEvents(
+    ParamsCacheMixin,
     SelectorMixin,
     CalibratorsMixin,
     ChunkedIOMixin,

--- a/columnflow/timing.py
+++ b/columnflow/timing.py
@@ -1,0 +1,90 @@
+import time
+from collections import defaultdict
+import functools
+
+prev_timing_dict = defaultdict(bool)
+timing_dict = defaultdict(bool)
+prev_counting_dict = defaultdict(bool)
+counting_dict = defaultdict(bool)
+
+
+def update_timing(key, dt, min_dt=5, count=False, min_count=10):
+    timing_dict[key] += dt
+    if timing_dict[key] - prev_timing_dict[key] > min_dt:
+        print(key, timing_dict[key])
+        prev_timing_dict[key] = timing_dict[key]
+
+    if count:
+        counting_dict[key] += 1
+        if counting_dict[key] - prev_counting_dict[key] > min_count:
+            print(key, counting_dict[key])
+            prev_counting_dict[key] = counting_dict[key]
+
+
+def timer(func=None, *, tag=None, min_dt=5, count=False, min_count=10):
+    """
+    decorator to time a function call.
+    Total time is printed to terminal (time per call X number of calls).
+    Several functions can be grouped by providing a tag.
+    Also the number of calls can be printed if *count=True*
+    The minimum time / number of calls to trigger a print can also be specified
+
+    @timer
+    def my_func():
+        ...
+
+    OUT: my_func <time if time>
+
+    @timer(tag="tag")
+    def my_func():
+        ...
+
+    OUT: tag <time> (sum of all functions with this tag)
+    OUT: tag my_func <time>
+
+
+    """
+    wrap_kwargs = dict(minD_dt=min_dt, count=count, min_count=min_count)
+    def outer(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            t0 = time.time()
+            out = f(*args, **kwargs)
+            dt = time.time() - t0
+            if tag is not None:
+                update_timing(tag, dt, **wrap_kwargs)
+                update_timing((tag, f.__name__), dt, **wrap_kwargs)
+            else:
+                update_timing(f.__name__, dt, **wrap_kwargs)
+            return out
+        return wrapper
+    return outer if func is None else outer(func)
+
+
+class Timer:
+    """
+    Class to create timer objects.
+    Example:
+
+    tmr = Timer("my_timer")  # at t0
+    ...
+    tmr("checkpoint 1") # at t1
+    OUT: my_timer checkpoint 1 t1 - t0
+    ...
+    tmr("checkpoint 2") # at t2
+    OUT: my_timer checkpoint 2 t2 - t1
+
+    """
+    def __init__(self, tag):
+        self.t0 = self.tp = time.time()
+        self.dt = 5
+        self.tag = "\033[94m" + tag + "\033[0m"
+        print("\033[1msetup timer", tag, "\033[0m")
+
+    def __call__(self, tag=None, force=False):
+        t = time.time()
+        # if (t := time.time()) - self.tp > self.dt:
+        tag = self.tag + ("" if tag is None else f"\033[96m {tag}\033[0m")
+        if (t - self.tp > 0.01) or force:
+            print(tag, t - self.tp)
+        self.tp = t


### PR DESCRIPTION
Every task (in luigi) has a function called get_param_values, which is called to initialize the task. I found that calling this function can take a significant amount of time: in my analysis, for instance, it took 3 seconds for a task like `cf.PlotVariables1D`. The problem is, that a task which has a branch option is reinitialized for every branch value. In my case, it took, therefore, at least half an hour just to initialize `cf.PlotVariables1D` with like 500 plots, and likely even more (I never waited till the end). It seems like the time of one call can however depend on t2b, so maybe if t2b runs smoothly this might not be so much of a problem.

I solved this issue with a mixin to be added to the tasks, which overwrites `get_param_values` so that it stores the output from the first call, returns this output with some adaptations on the next calls. These adaptations include 
- the branch number of the current call
- the dataset of the current call
- the values of "print_output", "branches", "print_status", "remove_output", "fetch_output" are set to their default values (creates otherwise an infinite loop)

One caveat: I am not sure how much the changing of the branch number or the dataset affects the values of the other parameters. But I found myself no difference between the normal call  to `get_param_values` and the procedure I follow above.

I added following options:
- `--time-get-params`: time the call to get_param_values to check how seriously this problem affects you
- `--check-cached-params`: compare the cached output to a normal call and report any difference (no efficiency gained!)
- `--no-cached-params`: don't use the cached params, but only use normal calls 

