### PR TITLE
none protect jec branches

### DIFF
--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -851,6 +851,7 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     )
 
     # ensure array is not nullable (avoid ambiguity on Arrow/Parquet conversion)
+    smear_factors = ak.nan_to_none(smear_factors)
     smear_factors = ak.fill_none(smear_factors, 0.0)
 
     # store pt and phi of the full jet system

--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -850,8 +850,10 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
         smear_factors_stochastic,
     )
 
-    # ensure array is not nullable (avoid ambiguity on Arrow/Parquet conversion)
+    # ensure array with correctionlib output 'Nan' are set to 0.0 in the next line
     smear_factors = ak.nan_to_none(smear_factors)
+
+    # ensure array is not nullable (avoid ambiguity on Arrow/Parquet conversion)
     smear_factors = ak.fill_none(smear_factors, 0.0)
 
     # store pt and phi of the full jet system


### PR DESCRIPTION
Smear factors for some reason sometimes turned out to be nan (zero division I assume), so added a proper nan to none conversion.