### PR TITLE
Split multi-dim variables

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1980,9 +1980,9 @@ class VariablesMixin(ConfigTask):
                 new_variables = []
                 for variable in params["variables"]:
                     if variable in groups:
-                        new_variables.extend( groups[variable] )
+                        new_variables.extend(groups[variable])
                     else:
-                        new_variables.append( variable )
+                        new_variables.append(variable)
                 params["variables"] = tuple(new_variables)
 
                 # first, split into single- and multi-dimensional variables

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1975,6 +1975,16 @@ class VariablesMixin(ConfigTask):
 
             # resolve them
             if params["variables"]:
+                # first try to resolve variable groups
+                groups = config_inst.x("variable_groups", {})
+                new_variables = []
+                for variable in params["variables"]:
+                    if variable in groups:
+                        new_variables.extend( groups[variable] )
+                    else:
+                        new_variables.append( variable )
+                params["variables"] = tuple(new_variables)
+
                 # first, split into single- and multi-dimensional variables
                 single_vars = []
                 multi_var_parts = []


### PR DESCRIPTION
Currently, if variable groups containing multi-dim variables are passed to the cmd line, the variables names are not resolved before passing them to the multi-dim-variable-identifier.

With this update, first all variable names are resolved, and then the multi-dim identification is performed as usual.

For reference:
```
--variables groupA,groupB
```
with `groupA = ["X-Y", "Z-A"]`, etc. did not work before and the variables had to be explicitly calledas
```
--variables X-Y,Z-A
```
in order to be correctly identified.
