### PR TITLE
initial fix to add smearing to jec uncertainty variations and jec var…

### DIFF
--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -863,9 +863,9 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
 
     # store pt and phi of the full jet system
     if self.propagate_met:
-        jetsum_before = events[jet_name].sum(axis=1)
-        jetsum_pt_before = jetsum_before.pt
-        jetsum_phi_before = jetsum_before.phi
+        jetsum = events[jet_name].sum(axis=1)
+        jetsum_pt_before = jetsum.pt
+        jetsum_phi_before = jetsum.phi
 
     # apply the smearing factors to the pt and mass
     # (note: apply variations first since they refer to the original pt)

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -107,6 +107,11 @@ def pdf_weights(
             events = set_ak_column_f32(events, "pdf_weight", ones)
             events = set_ak_column_f32(events, "pdf_weight_up", ones)
             events = set_ak_column_f32(events, "pdf_weight_down", ones)
+
+        events = set_ak_column_f32(events, "alphas_weight", ones)
+        events = set_ak_column_f32(events, "alphas_weight_up", ones)
+        events = set_ak_column_f32(events, "alphas_weight_down", ones)
+
         return events
 
     # complain when the number of weights is unexpected
@@ -212,6 +217,10 @@ def pdf_weights(
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight", 0)
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_up", 0)
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_down", 0)
+
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight_up", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight_down", 0)
 
     return events
 


### PR DESCRIPTION
This pull request intends to fix Jet energy resolution smearing. The issue is that in current implementation the jet energy resolution smearing is applied only to the nominal `Jet.pt` and `Jet.mass` without looking at Jet Energy Correction (JEC) uncertainty variations. The same smearing needs to be also applied to the columns `Jet.{pt,mass}_jec_{jec_uncertainty_name}_{shift}` for each JEC uncertainty variation. In addition the smearing needs to be propagate to MET if `self.propagate_met=True` for each JEC uncertainty variation. This pull request fixes these issues by 're-producing' these columns with the smearing factor applied and the same for MET if requested.

**Checks**
- Currently all JEC uncertainty variations are calculated in the jec producer instead of only the uncertainties in `self.uncertainty_sources`. Should this be changed for efficiency?
- Is this implemenation bug-proof?
- ~~Should the possibility for a shift that includes both JEC and JER  uncertainty variations be included?~~

**This merge-request is deprecated and will be taken from central columnflow instead. For updates see #92**