### PR TITLE
where pdf weight is invalid fill 0's to alphas_weights and if all eve…

### DIFF
--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -107,6 +107,11 @@ def pdf_weights(
             events = set_ak_column_f32(events, "pdf_weight", ones)
             events = set_ak_column_f32(events, "pdf_weight_up", ones)
             events = set_ak_column_f32(events, "pdf_weight_down", ones)
+
+        events = set_ak_column_f32(events, "alphas_weight", ones)
+        events = set_ak_column_f32(events, "alphas_weight_up", ones)
+        events = set_ak_column_f32(events, "alphas_weight_down", ones)
+
         return events
 
     # complain when the number of weights is unexpected
@@ -212,6 +217,10 @@ def pdf_weights(
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight", 0)
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_up", 0)
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_down", 0)
+
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight_up", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight_down", 0)
 
     return events
 


### PR DESCRIPTION
Small fixes to alpha_s weights `calculation production/cms/pdf.py`
- If no events have pdf_weight columns with 101 or 103 inputs then the alpha_s weights are set to 1 by default.
- If pdf_weights are invalid (aka pdf_weight_nominal is zero) set also alpha_s weights to 0