### PR TITLE
GhentAnalysis template update may

### DIFF
--- a/analysis_templates/ghent_template/__cf_module_name__/calibration/default.py
+++ b/analysis_templates/ghent_template/__cf_module_name__/calibration/default.py
@@ -11,6 +11,9 @@ from columnflow.util import maybe_import
 
 ak = maybe_import("awkward")
 
+# derive the nominal jer without jec variations
+jer_nominal = jer.derive("jer_nominal", cls_dict={"jec_uncertainty_sources": []})
+
 
 @calibrator(
     uses={deterministic_seeds},
@@ -57,7 +60,7 @@ def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
         events = self[jec_nominal](events, **kwargs)
     else:
         events = self[jec_nominal](events, **kwargs)
-        events = self[jer](events, **kwargs)
+        events = self[jer_nominal](events, **kwargs)
 
     return events
 
@@ -71,7 +74,7 @@ def skip_jecunc_init(self: Calibrator) -> None:
     if self.dataset_inst.is_data:
         calibrators = {jec_nominal}
     else:
-        calibrators = {jec_nominal, jer}
+        calibrators = {jec_nominal, jer_nominal}
 
     self.uses |= calibrators
     self.produces |= calibrators

--- a/analysis_templates/ghent_template/__cf_module_name__/config/config___cf_short_name_lc__.py
+++ b/analysis_templates/ghent_template/__cf_module_name__/config/config___cf_short_name_lc__.py
@@ -161,7 +161,7 @@ def add_config(
             # extra columns
         } | four_vec(  # Jets
             {"Jet"},
-            {"btagDeepFlavB", "btagDeepFlavCvB"},
+            {"btagDeepFlavB", "btagDeepFlavCvB", "hadronFlavour"},
         ) | four_vec(  # Leptons
             {"Electron", "Muon", },
             {"deltaEtaSC"},

--- a/analysis_templates/ghent_template/__cf_module_name__/config/variables.py
+++ b/analysis_templates/ghent_template/__cf_module_name__/config/variables.py
@@ -43,11 +43,4 @@ def add_variables(config: od.Config) -> None:
         x_title="Gen-level Top pT",
         unit="GeV",
     )
-    config.add_variable(
-        "jet1_pt",
-        expression="Jet.pt[:,0]",
-        null_value=EMPTY_FLOAT,
-        binning=(30, 0, 300),
-        x_title=r"Leading Jet $p_T$",
-        unit="GeV",
-    )
+


### PR DESCRIPTION
Major changes:
- fixes to calibration that allows for running the nominal jec calibrations and also jer without requiring the jec variations.
- add `Jet.hadronFlavour` to ReduceEvents keep_columns in config
- Remove dublicate `jet1_pt` variable in config