### PR TITLE
Ghent analysis/lepton calibration fix2024

### DIFF
--- a/columnflow/calibration/cms/egamma.py
+++ b/columnflow/calibration/cms/egamma.py
@@ -188,7 +188,7 @@ class egamma_scale_corrector(Calibrator):
         """
         self.uses |= {
             # nano columns
-            f"{self.source_field}.{{seedGain,pt,superclusterEta,r9}}",
+            f"{self.source_field}.{{seedGain,pt,eta,phi,superclusterEta,r9}}",
             "run",
             optional_column(f"{self.source_field}.rawPt"),
         }
@@ -351,6 +351,7 @@ class egamma_resolution_corrector(Calibrator):
         # prepare arguments
         variable_map = {
             "AbsScEta": np.abs(sceta),
+            "ScEta": sceta,  # 2024 version
             "eta": sceta,
             "r9": r9,
             "pt": pt,
@@ -435,7 +436,7 @@ class egamma_resolution_corrector(Calibrator):
         """
         self.uses |= {
             # nano columns
-            f"{self.source_field}.{{pt,superclusterEta,r9}}",
+            f"{self.source_field}.{{pt,eta,phi,superclusterEta,r9}}",
             optional_column(f"{self.source_field}.rawPt"),
         }
         self.produces |= {

--- a/columnflow/production/cmsGhent/btag_weights.py
+++ b/columnflow/production/cmsGhent/btag_weights.py
@@ -41,7 +41,7 @@ def init_btag(self: Producer, add_eff_vars=True):
         self.btag_config = self.get_btag_config()
 
     # update used columns
-    self.uses.add(f"Jet.{self.btag_config.discriminator }")
+    self.uses.add(f"Jet.{self.btag_config.discriminator}")
 
     if add_eff_vars:
         if "default_btag_variables" not in self.config_inst.aux:


### PR DESCRIPTION
Addition of eta and phi to lepton calibration to ensure they are loaded as four vectors. Also added `ScEta` in `variable_map` as this is new for 2024 data-taking.