### PR TITLE
fix: memory intensive lil_matrix

### DIFF
--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -489,7 +489,7 @@ def normalization_weights_setup(
         )
 
     # setup the event weight lookup table
-    process_weight_table = scipy.sparse.lil_matrix((max(process_ids) + 1, 1), dtype=np.float32)
+    process_weight_table = scipy.sparse.dok_matrix((max(process_ids) + 1, 1), dtype=np.float32)
 
     def fill_weight_table(process_inst: od.Process, xsec: float, sum_weights: float) -> None:
         if sum_weights == 0:


### PR DESCRIPTION
lil_matrix takes up exorbitant amounts of memory as soon as the process ID get large, while dok_matrix does the job independently of process ID size.