### PR TITLE
Pin gfal/xrootd versions in setup.sh due to xrootd issue

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -670,9 +670,10 @@ EOF
                     "python=${pyv}" \
                     git \
                     git-lfs \
-                    gfal2 \
+                    "gfal2=2.23.1" \
                     gfal2-util \
-                    python-gfal2 \
+                    "python-gfal2=1.13.0" \
+                    "xrootd=5.8.4" \
                     myproxy \
                     conda-pack \
                     || return "$?"


### PR DESCRIPTION
Pin gfal2/xrootd/python-gfal2 versions to avoid XRootD 6.x fork-safety bug

Unpinned installs pull xrootd>=6.1.0 from conda-forge, which hangs or raises a TLS error when a process reuses an already-open XRootD connection after fork() -- exactly what law/luigi do for every task worker. Reproduced deterministically against both IIHE T2B and CERN's global CMS redirector; xrootd=5.8.4 does not show this behavior.

Pin gfal2=2.23.1, python-gfal2=1.13.0, xrootd=5.8.4 as a workaround until this is fixed upstream (https://github.com/xrootd/xrootd).